### PR TITLE
First try at integrating the Juntek-VAT1300 - style shunts using RS485

### DIFF
--- a/ESPController/include/DIYBMSServer.h
+++ b/ESPController/include/DIYBMSServer.h
@@ -124,7 +124,7 @@ extern avrprogramsettings _avrsettings;
 extern RelayState previousRelayState[RELAY_TOTAL];
 extern currentmonitoring_struct currentMonitor;
 extern void ConfigureRS485();
-extern void CurrentMonitorSetBasicSettings(uint16_t shuntmv, uint16_t shuntmaxcur);
-extern void CurrentMonitorSetAdvancedSettings(currentmonitoring_struct newvalues);
-extern void CurrentMonitorSetRelaySettings(currentmonitoring_struct newvalues);
+extern void CurrentMonitorSetBasicSettings_diyBMS(uint16_t shuntmv, uint16_t shuntmaxcur);
+extern void CurrentMonitorSetAdvancedSettings_diyBMS(currentmonitoring_struct newvalues);
+extern void CurrentMonitorSetRelaySettings_diyBMS(currentmonitoring_struct newvalues);
 #endif

--- a/ESPController/include/defines.h
+++ b/ESPController/include/defines.h
@@ -11,6 +11,7 @@
 #ifndef DIYBMS_DEFINES_H_
 #define DIYBMS_DEFINES_H_
 
+
 //Data uses Rx2/TX2 and debug logs go to serial0 - USB
 #define SERIAL_DATA Serial2
 #define SERIAL_DEBUG Serial
@@ -22,7 +23,13 @@
 typedef union
 {
   float value;
+  uint8_t byte[4];  
   uint16_t word[2];
+  uint32_t dword;
+  int8_t ubyte[4];  
+  int16_t uword[2];
+  int32_t udword;
+
 } FloatUnionType;
 
 enum RGBLED : uint8_t
@@ -73,6 +80,13 @@ enum RelayType : uint8_t
   RELAY_PULSE = 0x01
 };
 
+enum MODBUS_PROTOCOL
+{
+  modbusProtocol_diyBMS = 0,
+  modbusProtocol_Juntek = 1,
+  modbusProtocol_unknown = 0xFF
+};
+
 #define RELAY_RULES 12
 //Number of relays on board (4)
 #define RELAY_TOTAL 4
@@ -114,6 +128,9 @@ struct diybms_eeprom_settings
 
   bool currentMonitoringEnabled;
   uint8_t currentMonitoringModBusAddress;
+
+  uint8_t juntekShuntChannelLetter;
+  uint8_t juntekShuntChannelNumber;
 
   int rs485baudrate;
   uart_word_length_t rs485databits;
@@ -259,6 +276,7 @@ struct currentmonitoring_struct
 {
   //Uses float as these are 4 bytes on ESP32
   int64_t timestamp;
+  uint32_t seconds_of_activity;
   bool validReadings;
   float voltage;
   float current;
@@ -267,6 +285,7 @@ struct currentmonitoring_struct
   int16_t temperature;
   uint16_t watchdogcounter;
   float power;
+  float energy;
   float shuntmV;
   float currentlsb;
   float shuntresistance;

--- a/ESPController/platformio.ini
+++ b/ESPController/platformio.ini
@@ -40,7 +40,7 @@ platform = espressif32
 ;https://docs.platformio.org/en/latest/boards/espressif32/esp32dev.html
 board = esp32dev
 monitor_speed = 115200
-monitor_port=COM4
+monitor_port=COM3
 monitor_filters = log2file, esp32_exception_decoder
 board_build.flash_mode = dout
 extra_scripts =
@@ -50,8 +50,13 @@ extra_scripts =
         pre:prebuild_generate_embedded_files.py
         pre:bmp2array4bit.py
         LittleFSBuilder.py
+upload_protocol = espota
+upload_port = 192.168.254.89
+upload_flags =
+    --port=3232
+    --auth=1jiOOx12AQgEco4e
 upload_speed=921600
-upload_port=COM4
+# upload_port=COM3
 
 ; Use github version of the framework
 ;platform_packages =
@@ -88,7 +93,7 @@ build_type = debug
 build_flags = ${common.build_flags}
 build_type = debug
 upload_protocol = espota
-upload_port = 192.168.0.35
+upload_port = 192.168.254.89
 upload_flags =
     --port=3232
     --auth=1jiOOx12AQgEco4e

--- a/ESPController/src/DIYBMSServer.cpp
+++ b/ESPController/src/DIYBMSServer.cpp
@@ -513,7 +513,7 @@ void DIYBMSServer::saveCurrentMonRelay(AsyncWebServerRequest *request)
     newvalues.RelayTriggerPowerOverLimit = p1->value().equals("on") ? true : false;
   }
 
-  CurrentMonitorSetRelaySettings(newvalues);
+  CurrentMonitorSetRelaySettings_diyBMS(newvalues);
 
   SendSuccess(request);
 }
@@ -567,7 +567,7 @@ void DIYBMSServer::saveCurrentMonAdvanced(AsyncWebServerRequest *request)
     newvalues.shunttempcoefficient = p1->value().toInt();
   }
 
-  CurrentMonitorSetAdvancedSettings(newvalues);
+  CurrentMonitorSetAdvancedSettings_diyBMS(newvalues);
 
   SendSuccess(request);
 }
@@ -585,7 +585,7 @@ void DIYBMSServer::saveCurrentMonBasic(AsyncWebServerRequest *request)
     AsyncWebParameter *p2 = request->getParam("shuntmv", true);
     int shuntmv = p2->value().toInt();
 
-    CurrentMonitorSetBasicSettings(shuntmv, shuntmaxcur);
+    CurrentMonitorSetBasicSettings_diyBMS(shuntmv, shuntmaxcur);
   }
 
   SendSuccess(request);
@@ -611,6 +611,18 @@ void DIYBMSServer::saveCurrentMonSettings(AsyncWebServerRequest *request)
   {
     AsyncWebParameter *p1 = request->getParam("modbusAddress", true);
     _mysettings->currentMonitoringModBusAddress = p1->value().toInt();
+  }
+
+  if (request->hasParam("juntekShuntChannelLetter", true))
+  {
+    AsyncWebParameter *p1 = request->getParam("juntekShuntChannelLetter", true);
+    _mysettings->juntekShuntChannelLetter = p1->value().toInt();
+  }
+  
+  if (request->hasParam("juntekShuntChannelNumber", true))
+  {
+    AsyncWebParameter *p1 = request->getParam("juntekShuntChannelNumber", true);
+    _mysettings->juntekShuntChannelNumber = p1->value().toInt();
   }
 
   if (_mysettings->currentMonitoringEnabled == false)

--- a/ESPController/web_src/default.htm
+++ b/ESPController/web_src/default.htm
@@ -547,9 +547,25 @@
                         <select name="modbusAddress" id="modbusAddress">
                             <option value="90">90 [default]</option>
                             <option value="98">98</option>
+                            <option value="170">AA [Juntek]</option>
                         </select>
                     </div>
-
+                    <div>
+                        <label for="juntekShuntChannelLetter">Juntek channel (letter)</label>
+                        <select name="juntekShuntChannelLetter" id="juntekShuntChannelLetter">
+                            <option value="1">A</option>
+                            <option value="2">B</option>
+                            <option value="3">C</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="juntekShuntChannelNumber">Juntek channel (number)</label>
+                        <select name="juntekShuntChannelNumber" id="juntekShuntChannelNumber">
+                            <option value="1">1</option>
+                            <option value="3">3</option>
+                            <option value="11">11</option>
+                        </select>
+                    </div>
                     <input type="submit" value="Save connection settings" />
                 </div>
             </form>
@@ -568,6 +584,7 @@
                             <option value="9600">9600</option>
                             <option value="19200">19200</option>
                             <option value="38400">38400</option>
+                            <option value="57600">57600</option>
                         </select>
                     </div>
                     <div>


### PR DESCRIPTION
This is my first shot at integrating the Juntek shunt in diyBMS. It is not intended for a merge, but more as a base for discussions. 

It uses the current structure, with the differing functions broken out to separate functions. E.g. the register parsing, and the checksums are done differently. These were re-implemented with the shunt type as a suffix, e.g. calculateCRC_juntek() and calculateCRC_dyibms().

I have only implemented parsing of voltage, current and power so far. No changing of settings of the shunt etc. is implemented.

This works but is a bit cumbersome if you intend to implement integration with more devices,  e.g. solar controllers etc.  Ideally the handling should be protocol agnostic.

Are there any plans to implement any functionality like this? Any ideas on how to proceed?
