### PR TITLE
Ensure http server returns connected clients for log broadcast

### DIFF
--- a/ESPController/src/webserver.cpp
+++ b/ESPController/src/webserver.cpp
@@ -333,7 +333,7 @@ void clearModuleValues(uint8_t module)
 
 extern "C" int log_output_redirector(const char * format, va_list args)
 {
-  size_t fd_count = 0;
+  size_t fd_count = CONFIG_LWIP_MAX_LISTENING_TCP;
   int client_fds[CONFIG_LWIP_MAX_LISTENING_TCP] = {0};
   httpd_ws_frame_t ws_pkt = {};
   char log_buffer[64];


### PR DESCRIPTION
This should fix the WS log broadcast.

It may also be beneficial to add an ifdef block around https://github.com/stuartpittaway/diyBMSv4ESP32/blob/d774a47387fc5c7694c3f347211c646bfc42cbfe/ESPController/src/webserver.cpp#L416 so the WS log redirect can be disabled if it becomes an issue.