### PR TITLE
SOC reset fix and possible solution for random "Current monitor under voltage" rule trigger

### DIFF
--- a/ESPController/src/CurrentMonitorINA229.cpp
+++ b/ESPController/src/CurrentMonitorINA229.cpp
@@ -411,7 +411,7 @@ void CurrentMonitorINA229::CalculateAmpHourCounts()
     else
     {
         // Voltage or current is out side of monitoring limits, so set timer to now + 3 minutes
-        int64_t soc_reset_time = esp_timer_get_time() + (3 * 60000000L);
+        soc_reset_time = esp_timer_get_time() + (3 * 60000000L);
     }
 }
 

--- a/ESPController/src/main.cpp
+++ b/ESPController/src/main.cpp
@@ -2553,7 +2553,7 @@ void ProcessDIYBMSCurrentMonitorRegisterReply(uint8_t length)
 // Extract onboard/internal current monitor values into our internal STRUCTURE variables
 void ProcessDIYBMSCurrentMonitorInternal()
 {
-  memset(&currentMonitor.modbus, 0, sizeof(currentmonitor_raw_modbus));
+  //memset(&currentMonitor.modbus, 0, sizeof(currentmonitor_raw_modbus));
   currentMonitor.validReadings = false;
 
   currentMonitor.timestamp = esp_timer_get_time();


### PR DESCRIPTION
Hello Stuart,

I've noticed that the SOC resets to 100% immediately when `fully_charged_voltage` and `tail_current_amps` condition is reached. The code suggests that SOC reset should happen only if the condition is valid for 3 minutes. I guess that's the role of `soc_reset_time` class member variable. However, in the "else" part of the code, where the `soc_reset_time` is being set to "current time + 3 minutes", a local variable with the same name (unintended shadowing?) `int64_t soc_reset_time` is used,  so the original member variable is never updated. This is fixed in a8f3279.

The second commit in this PR is aiming to fix an issue with random trigger of "Current monitor under voltage" rule. It's quite rare, I think it happened like ten times per year. When `ProcessDIYBMSCurrentMonitorInternal()` is called, firstly, it clears the internal `currentMonitor` struct and then fills it with new data from INA229. From my understanding, the FreeRTOS may switch between tasks any time, so it may happen that right after `memset(&currentMonitor.modbus, 0, sizeof(currentmonitor_raw_modbus));` from `ProcessDIYBMSCurrentMonitorInternal()` in `rs485_tx` task, the `rules_task` is being executed and working on zeroed `currentMonitor`, triggering the "Current monitor under voltage" rule.

If I remove the `memset()`,  the rule check executed from `rules_task` should never see the zero struct. At worst, it will work on partially updated currentMonitor struct - when the context was switched from `rs485_tx` task to `rules_task` right in the middle of `ProcessDIYBMSCurrentMonitorInternal()` update.