### PR TITLE
Changed Float duration to be configureable for hrs+days

### DIFF
--- a/ESPController/src/webserver_json_post.cpp
+++ b/ESPController/src/webserver_json_post.cpp
@@ -523,7 +523,7 @@ esp_err_t post_savechargeconfig_json_handler(httpd_req_t *req, bool urlEncoded)
     GetKeyValue(httpbuf, "kneemv", &mysettings.kneemv, urlEncoded);
     GetKeyValue(httpbuf, "cellmaxspikemv", &mysettings.cellmaxspikemv, urlEncoded);
 
-    float temp_float;
+    float temp_float, temp_float2;
 
     if (GetKeyValue(httpbuf, "cur_val1", &temp_float, urlEncoded))
     {
@@ -584,7 +584,13 @@ esp_err_t post_savechargeconfig_json_handler(httpd_req_t *req, bool urlEncoded)
     {
         mysettings.floatvoltage = (uint16_t)(10 * temp_float);
     }
-    GetKeyValue(httpbuf, "floattimer", &mysettings.floatvoltagetimer, urlEncoded);
+
+    if (GetKeyValue(httpbuf, "floatday", &temp_float, urlEncoded) &&
+        GetKeyValue(httpbuf, "floathour", &temp_float2, urlEncoded))
+    {
+        mysettings.floatvoltagetimer = (uint16_t)(temp_float * 1440 + temp_float2 * 60); //we can store up to 44days with uint16_t 
+    }
+
     GetKeyValue(httpbuf, "socresume", &mysettings.stateofchargeresumevalue, urlEncoded);
 
     if (mysettings.protocol == ProtocolEmulation::EMULATION_DISABLED)

--- a/ESPController/src/webserver_json_requests.cpp
+++ b/ESPController/src/webserver_json_requests.cpp
@@ -636,7 +636,12 @@ esp_err_t content_handler_chargeconfig(httpd_req_t *req)
   settings["cur_val2"] = mysettings.current_value2;
 
   settings["absorptimer"] = mysettings.absorptiontimer;
-  settings["floattimer"] = mysettings.floatvoltagetimer;
+
+  float hrs_quarter = std::round(((float)mysettings.floatvoltagetimer / 60) * 4) / 4; // round minutes to nearest quarter hour
+  float days = std::trunc(hrs_quarter / 24);
+
+  settings["floatday"] =  days; // # of days;
+  settings["floathour"] = hrs_quarter - 24 * days; //remaining hours
   settings["socresume"] = mysettings.stateofchargeresumevalue;
   settings["floatvolt"] = mysettings.floatvoltage;
 

--- a/ESPController/web_src/default.htm
+++ b/ESPController/web_src/default.htm
@@ -1098,8 +1098,10 @@
             <input id="floatvolt" name="floatvolt" value="" type="number" min="1" max="999.9" step="0.1" />
           </div>
           <div>
-            <label for="floattimer">'Float' timer (minutes)</label>
-            <input id="floattimer" name="floattimer" value="" type="number" min="1" max="720" step="1" />
+            <label for="floatday">'Float' timer (Days)</label>
+            <input id="floatday" name="floatday" value="" type="number" min="0" max="28" step="1" />
+            <label for="floathour">  (Hours)</label>
+            <input id="floathour" name="floathour" value="" type="number" min="0" max="23.75" step="0.25" />
           </div>
           <div>
             <label for="socresume">S.o.C charge resume</label>

--- a/ESPController/web_src/pagecode.js
+++ b/ESPController/web_src/pagecode.js
@@ -2039,7 +2039,8 @@ $(function () {
                 $("#dischargetemphigh").val(data.chargeconfig.dischargetemphigh);
 
                 $("#absorptimer").val(data.chargeconfig.absorptimer);
-                $("#floattimer").val(data.chargeconfig.floattimer);
+                $("#floatday").val(data.chargeconfig.floatday.toFixed(0)); 
+                $("#floathour").val(data.chargeconfig.floathour.toFixed(2)); 
                 $("#socresume").val(data.chargeconfig.socresume);
                 $("#floatvolt").val((data.chargeconfig.floatvolt / 10.0).toFixed(1));
 


### PR DESCRIPTION
In many mobile application is is desirable to keep the BMS in float mode for longer periods of time. This allows charge sources to supply loads without cycling the battery. Eventually it must still end so that the charge cycle can restart and allow cells to rebalance. See further discussion in issue #310 . The format of the timer has been changed from minutes to days+hrs. It allows 15minute increments with a max total time of 28 days, 23.75hrs. 