### PR TITLE
ATtiny1624: board definition now forces a second millis timer

### DIFF
--- a/ATTINYCellModule/platformio.ini
+++ b/ATTINYCellModule/platformio.ini
@@ -48,7 +48,10 @@ lib_deps =
 ;DIYBMS V4.50
 ;Completely different design using ATTINY1624 chip
 ;MV_PER_ADC is not used by this code, SAMPLEAVERAGING is done in hardware, so set to 1
-build_flags=-DMILLIS_USE_TIMERB0=1 -DDIYBMSMODULEVERSION=450 -DMV_PER_ADC=1 -DINT_BCOEFFICIENT=3950 -DEXT_BCOEFFICIENT=3950 -DLOAD_RESISTANCE=3.30 -DDIYBMSBAUD=2400 -DSAMPLEAVERAGING=1
+; The ATtiny1624 board definition sets -DMILLIS_USE_TIMERB1, which collides with the
+; -DMILLIS_USE_TIMERB0 this project needs.  -U cancels it: PlatformIO drops the matching
+; -D when it merges the flags, whatever defined it.
+build_flags=-UMILLIS_USE_TIMERB1 -DMILLIS_USE_TIMERB0=1 -DDIYBMSMODULEVERSION=450 -DMV_PER_ADC=1 -DINT_BCOEFFICIENT=3950 -DEXT_BCOEFFICIENT=3950 -DLOAD_RESISTANCE=3.30 -DDIYBMSBAUD=2400 -DSAMPLEAVERAGING=1
 platform = https://github.com/platformio/platform-atmelmegaavr.git
 lib_ldf_mode = chain+
 lib_compat_mode = strict
@@ -70,7 +73,10 @@ board_hardware.eesave = no
 ;DIYBMS V4.50
 ;Completely different design using ATTINY1624 chip
 ;MV_PER_ADC is not used by this code, SAMPLEAVERAGING is done in hardware, so set to 1
-build_flags=-DMILLIS_USE_TIMERB0=1 -DDIYBMSMODULEVERSION=450 -DMV_PER_ADC=1 -DINT_BCOEFFICIENT=3950 -DEXT_BCOEFFICIENT=3950 -DLOAD_RESISTANCE=3.30 -DDIYBMSBAUD=10000 -DSAMPLEAVERAGING=1
+; The ATtiny1624 board definition sets -DMILLIS_USE_TIMERB1, which collides with the
+; -DMILLIS_USE_TIMERB0 this project needs.  -U cancels it: PlatformIO drops the matching
+; -D when it merges the flags, whatever defined it.
+build_flags=-UMILLIS_USE_TIMERB1 -DMILLIS_USE_TIMERB0=1 -DDIYBMSMODULEVERSION=450 -DMV_PER_ADC=1 -DINT_BCOEFFICIENT=3950 -DEXT_BCOEFFICIENT=3950 -DLOAD_RESISTANCE=3.30 -DDIYBMSBAUD=10000 -DSAMPLEAVERAGING=1
 platform = https://github.com/platformio/platform-atmelmegaavr.git
 lib_ldf_mode = chain+
 lib_compat_mode = strict
@@ -92,7 +98,10 @@ board_hardware.eesave = no
 ;DIYBMS V4.50
 ;Completely different design using ATTINY1624 chip
 ;MV_PER_ADC is not used by this code, SAMPLEAVERAGING is done in hardware, so set to 1
-build_flags=-DMILLIS_USE_TIMERB0=1 -DDIYBMSMODULEVERSION=450 -DMV_PER_ADC=1 -DINT_BCOEFFICIENT=3950 -DEXT_BCOEFFICIENT=3950 -DLOAD_RESISTANCE=3.30 -DDIYBMSBAUD=5000 -DSAMPLEAVERAGING=1
+; The ATtiny1624 board definition sets -DMILLIS_USE_TIMERB1, which collides with the
+; -DMILLIS_USE_TIMERB0 this project needs.  -U cancels it: PlatformIO drops the matching
+; -D when it merges the flags, whatever defined it.
+build_flags=-UMILLIS_USE_TIMERB1 -DMILLIS_USE_TIMERB0=1 -DDIYBMSMODULEVERSION=450 -DMV_PER_ADC=1 -DINT_BCOEFFICIENT=3950 -DEXT_BCOEFFICIENT=3950 -DLOAD_RESISTANCE=3.30 -DDIYBMSBAUD=5000 -DSAMPLEAVERAGING=1
 platform = https://github.com/platformio/platform-atmelmegaavr.git
 lib_ldf_mode = chain+
 lib_compat_mode = strict


### PR DESCRIPTION
A clean checkout of master no longer builds.  "pio run" in ATTINYCellModule
fails on the first three environments:

  core_parameters.h:47:4: error: "MILLIS_USE_TIMERB0 and another timer are
  set as the millis timer. Specify one only."
  core_parameters.h:52:4: error: "MILLIS_USE_TIMERB1 and another timer are
  set as the millis timer. Specify one only."

V450_2K4 / V450_5K / V450_10K all fail, on master, unmodified.

This also means the PlatformIO CI workflow cannot be passing.  The "Build code
for ATTINY modules" step runs "pio run" with no environment filter, so it
builds every entry in default_envs, and the following step copies
.pio/build/V*/*.hex - which the three missing V450 builds would break.

Cause: the ATtiny1624 board definition in platform-atmelmegaavr now carries

  "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V"

while platformio.ini passes -DMILLIS_USE_TIMERB0=1.  megatinycore refuses to
guess between them.  The platform is referenced as an unpinned git URL

  platform = https://github.com/platformio/platform-atmelmegaavr.git

so this arrived on its own, without any change to this repository.  Pinning the
platform to a known good revision would be an alternative fix, and probably a
good idea regardless.

TIMERB0 is not a preference here, the code requires it:

  src/diybms_tinyAVR2.cpp:45  #error "This sketch takes over TCA0 - please
                                     use a different timer for millis"
  src/diybms_tinyAVR2.cpp:48  #error "This sketch is written for use with
                                     TCB0 as the millis timing source"

TCA0 is taken over for the bypass PWM (takeOverTCA0(), TCA0_OVF_vect), so the
board's choice has to give way rather than the project's.

Fix: cancel the board's define with -U.  PlatformIO drops the matching -D when
it merges the flags, whatever defined it, and moves the -U to the end of the
define flags - this is deliberate, see the "Cancel any previous definition of
name, either built in or provided with a -U option" handling in
builder/tools/piobuild.py.

Overriding board_build.extra_flags works too, but that means restating
-DARDUINO_attinyxy4 and -DUARTBAUD5V here, where they would quietly go stale if
the board definition ever gains another flag - which is exactly how this broke.

Verified with PlatformIO Core 6.1.19 / megatinycore 2.6.11 by running the same
bare "pio run" the CI workflow uses.  All 12 environments build:

  V450_2K4 V450_10K V450_5K V400 V410 V420 V420_SWAPR19R20 V421 V421_LTO
  V440 V440_COMMS_5K V440_COMMS_9K6        12 succeeded

Only the three ATtiny1624 environments needed changing; the ATTINY841 ones use
a different platform and were already fine.
