### PR TITLE
Remove V490_AUTOBAUD_VREF4096 env - no such hardware exists

### DIFF
--- a/STM32All-In-One/platformio.ini
+++ b/STM32All-In-One/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = V490_AUTOBAUD_VREF4096, V490_AUTOBAUD_VREF4500
+default_envs = V490_AUTOBAUD_VREF4500
 
 [env]
 platform = platformio/ststm32@^17.5.0
@@ -33,18 +33,6 @@ upload_port = COM5
 debug_tool = stlink
 upload_protocol = stlink
 ;upload_protocol = serial
-
-[env:V490_AUTOBAUD_VREF4096]
-build_flags=
-      -DDIYBMSMODULEVERSION=490 
-      -DINT_BCOEFFICIENT=3950 
-      -DEXT_BCOEFFICIENT=3950 
-      -DLOAD_RESISTANCE=18.0 
-      -DDIYBMSREFMILLIVOLT=4096 
-      -DADC_SAMPLINGTIME=ADC_SAMPLETIME_239CYCLES_5
-      -DSERIAL_RX_BUFFER_SIZE=64 
-      -DSERIAL_TX_BUFFER_SIZE=64
-
 
 [env:V490_AUTOBAUD_VREF4500]
 build_flags=-DDIYBMSMODULEVERSION=490 


### PR DESCRIPTION
The 4.096V reference (U2, MCP1501-40xSN, SOIC-8) was removed from the
All-In-One V490 design. It is not present in the current schematic, PCB,
BOM or CPL:

  grep -c '"U2"' Module_16S.kicad_sch / STM32.kicad_sch / PowerSupply.kicad_sch -> 0 / 0 / 0
  grep -c '"U2"' Module_16S.kicad_pcb                                          -> 0
  grep 'MCP1501' schematic / BOM / CPL                                         -> 0 hits
  BOM U references: U1 U3 U4 U5 U6 U9 U10 U11 U12 U13   (no U2)

It was removed by the "All in one revision" work squashed into master as
26c335a (2025-04-18), which also deleted the TEST_4096 test point and
replaced the reference with U6 = MCP1502T-45E/CHY (4.500V, SOT-23-6):

  -"MCP1501-40xSN","U2","SOIC-8_3.9x4.9mm_P1.27mm","C1575589"
  +"MCP1502T-45E/CHY","U6","SOT-23-6","C5236158"

The stale env is dangerous, not merely dead: it was listed first in
default_envs, so it is the first artifact produced by a plain `pio run`.
Flashing it onto real hardware scales every cell voltage by
4096/4500 = 0.910, i.e. all cells read 9.0% LOW:

  a Li-ion cell at 4.20V is reported as 3.82V

Under-reporting cell voltage means over-voltage is never detected and
charging is not stopped - the failure is towards the unsafe side.

Related: stuartpittaway/diyBMSv4#200 reports the matching README text (which
still tells users to fit U2 for "LIFEPO4 cells up to 4.00V maximum"), and #250
reports V490 modules reading lower than actual, for which this env is one
possible cause.
