### PR TITLE
Web asset minification has been silently skipped

### DIFF
--- a/ESPController/prebuild_compress.py
+++ b/ESPController/prebuild_compress.py
@@ -5,10 +5,43 @@ import shutil
 import gzip
 import os
 import errno
+import sys
+import importlib
 Import('env')
 
-env.Execute("$PYTHONEXE -m pip install -v htmlmin")
-env.Execute("$PYTHONEXE -m pip install --upgrade htmlmin")
+
+def load_minifier():
+    # Only reach for pip when the minifier is not already usable.  Installing on every build
+    # costs a round trip to the package index each time, and an offline build on a machine
+    # that already has it has no reason to go looking.
+    #
+    # htmlmin2 is a maintained fork of htmlmin, which has had no release since 2020 and no
+    # longer installs at all: it imports "cgi", removed from the standard library in Python
+    # 3.13 (PEP 594).  The fork keeps the same module name.
+    for last_attempt in (False, True):
+        try:
+            import htmlmin
+            return htmlmin.minify
+        except (ImportError, AttributeError) as e:
+            if last_attempt:
+                # Carry on with unminified pages - a build without a network, or on a machine
+                # where pip is locked down, should still produce working firmware.  Say so
+                # loudly though: this used to happen silently, and the pages are not small.
+                print('  WARNING: cannot use htmlmin (%s)' % e)
+                print('  WARNING: pages will be embedded unminified, costing ~20kB of flash')
+                return None
+
+            print('  htmlmin not usable (%s), installing htmlmin2' % e)
+
+            # --force-reinstall also repairs the one messy case: both packages ship the same
+            # "htmlmin" package directory, so on a machine that had the original, removing it
+            # afterwards takes the shared files with it and leaves an importable but empty
+            # module.  A plain install would report "already satisfied" and change nothing.
+            env.Execute('"$PYTHONEXE" -m pip install --upgrade --force-reinstall htmlmin2')
+
+            # That empty module is already in sys.modules, so drop it before trying again.
+            sys.modules.pop('htmlmin', None)
+            importlib.invalidate_caches()
 
 
 def prepare_www_files():
@@ -57,11 +90,28 @@ def prepare_www_files():
         print('  Copying file: ' + file + ' to data dir')
         shutil.copy(file, data_dir)
 
+    # Call htmlmin through its module rather than its command line.  pip puts the console
+    # script next to whichever Python is running PlatformIO, and nothing adds that directory
+    # to PATH for the commands SCons runs, so "htmlmin ..." only resolved when PlatformIO
+    # happened to be installed into a Python already on PATH.
+    minify = load_minifier() if files_to_minify else None
+
     for file in files_to_minify:
+        destination = os.path.join(data_dir, os.path.basename(file))
+
+        if minify is None:
+            print('  Copying file UNMINIFIED: ' + file + ' to data dir')
+            shutil.copy(file, destination)
+            continue
+
         print('  Minify file: ' + file + ' to data dir')
-        shutil.copy(file, os.path.join(data_dir, os.path.basename(file)))
-        env.Execute("htmlmin  --keep-optional-attribute-quotes " +
-                    file+" "+os.path.join(data_dir, os.path.basename(file)))
+
+        with open(file, 'r', encoding='utf-8') as f_in:
+            content = f_in.read()
+
+        # remove_optional_attribute_quotes=False is the old --keep-optional-attribute-quotes.
+        with open(destination, 'w', encoding='utf-8') as f_out:
+            f_out.write(minify(content, remove_optional_attribute_quotes=False))
 
     for file in files_to_gzip:
         print('  GZipping file: ' + file + ' to data dir')


### PR DESCRIPTION
Two separate problems stop default.htm from ever being minified, and neither
one fails the build - prepare_www_files() copies the file first and then
overwrites it with the minified version, so when minification fails the plain
copy is simply left in place.

1. htmlmin can no longer be installed.  It has had no release since 2020, and
   its setup.py imports the package, which imports "cgi" - removed from the
   standard library in Python 3.13 (PEP 594):

     File ".../htmlmin/main.py", line 28, in <module>
       import cgi
     ModuleNotFoundError: No module named 'cgi'

   This is a Python version problem rather than a platform one - anyone whose
   PlatformIO virtualenv is built on 3.13 or newer hits it, on any OS.  CI pins
   Python 3.11 (.github/workflows/main.yml), which is why it has gone
   unnoticed.

   Switched to htmlmin2, a maintained fork which drops the cgi import in favour
   of html.escape and keeps the same module and command name.  It is not
   version specific - checked against 3.9 and 3.14, both minify this project's
   default.htm - so there is nothing to select between.

2. The minifier is invoked as a shell command, and is only found by luck.
   $PYTHONEXE is sys.executable, so pip installs the console script next to
   whichever Python is running PlatformIO.  platformio/proc.py only ever
   extends PYTHONPATH - nothing puts that script directory on PATH for the
   commands SCons runs.  So it resolves when PlatformIO was installed into a
   Python whose scripts directory is already on PATH ("pip install platformio",
   which is what CI does), and does not when PlatformIO lives in its own
   virtualenv, as the installer and the IDE extension set it up:

     sh: htmlmin: command not found
     *** Error 127

   Calling htmlmin.minify() directly removes the PATH dependency.

remove_optional_attribute_quotes=False is the old --keep-optional-attribute-quotes.

pip is now only invoked when the minifier is not already usable, rather than on
every build - it costs a round trip to the package index each time, and an
offline build on a machine that already has it had no reason to go looking.

The install uses --force-reinstall so it also repairs the one messy case.  Both
packages ship the same "htmlmin" package directory and pip does not check for
that overlap, so on a machine that already had the original, htmlmin2's files
simply land on top and minification starts working.  But removing the old
htmlmin afterwards takes the shared files with it and leaves an importable but
empty module, which a plain install would skip over as "already satisfied".

If the minifier still cannot be used - no network, or pip locked down - pages
are copied through unminified so the build produces working firmware, but it
now says so in the log rather than leaving it to be discovered by looking at
the binary size.

Result on an esp32-devkitc build: default.htm 84945 -> 65358 bytes, firmware
1705897 -> 1686313 bytes (96.4% -> 95.3% of the partition).  Verified that
every %TEMPLATE% keyword, every %% escape, and every id and name attribute
survives minification unchanged - default_htm_handler() substitutes those at
serve time, so they have to.
