### PR TITLE
ATtiny1624: clear SFDEN when awake (silicon errata DS80000902F 2.8.2)

### DIFF
--- a/ATTINYCellModule/include/diybms_tinyAVR2.h
+++ b/ATTINYCellModule/include/diybms_tinyAVR2.h
@@ -131,6 +131,18 @@ public:
     USART0.CTRLB |= USART_SFDEN_bm;
   }
 
+  // Start-of-Frame Detection must be switched off again as soon as we are awake.
+  // Silicon errata DS80000902F 2.8.2 "Start-of-Frame Detection Can Unintentionally
+  // Be Triggered in Active Mode": if RXDATA is read while new data is being received,
+  // RXCIF is cleared, the Start-of-Frame Detector is re-armed and falsely takes the
+  // next falling edge for a start bit.  Frame reception restarts and the received
+  // data is corrupted.  RXSIF stays '0' in Active mode and no interrupt is raised,
+  // so this is silent - it only shows up as CRC failures further up.
+  static inline void DisableStartFrameDetection() __attribute__((always_inline))
+  {
+    USART0.CTRLB &= ~(USART_SFDEN_bm);
+  }
+
   static void SetWatchdog8sec()
   {
     // Setup a watchdog timer for 8 seconds
@@ -163,6 +175,10 @@ public:
     // Snoring can be heard at this point....
 
     sleep_disable();
+
+    // We are in Active mode again - errata DS80000902F 2.8.2 requires SFDEN to be
+    // cleared here, it is set again just before the next sleep_cpu() above.
+    diyBMSHAL::DisableStartFrameDetection();
   }
 
   static void SelectCellVoltageChannel()


### PR DESCRIPTION
Start-of-Frame Detection is enabled in diyBMSHAL::Sleep() so the module wakes
from Standby on RX activity, but it is never cleared again, so the part runs in
Active mode with SFDEN set.  That is the condition described in
ATtiny1624/1626/1627 Silicon Errata DS80000902F 2.8.2, "Start-of-Frame
Detection Can Unintentionally Be Triggered in Active Mode":

  The Start-of-Frame Detector can unintentionally be triggered when the
  Start-of-Frame Detection Enable (SFDEN) bit in the USART Control B
  (USARTn.CTRLB) register is set, and the device is in Active mode. If the
  Receive Data (RXDATA) registers are read while receiving new data, the
  Receive Complete Interrupt Flag (RXCIF) in the USARTn.STATUS register is
  cleared. This triggers the Start-of-Frame Detector and falsely detects the
  next falling edge as a start bit. When the Start-of-Frame Detector detects a
  start condition, the frame reception is restarted, resulting in corrupt
  received data. Note that the USART Receive Start Interrupt Flag (RXSIF)
  always is '0' when in Active mode. No interrupt will be triggered.

Reading RXDATA while data is still arriving is not an edge case here, it is how
receiving works - HardwareSerial::_rx_complete_irq() reads RXDATAH and RXDATAL
to collect each byte, and the bytes of a packet arrive back to back, so the
read for one byte happens while the next is on the wire.

The corruption is silent.  RXSIF stays 0 and no interrupt is raised, so a
module has no way to report it; it only shows up as CRC failures or lost
packets further along the chain.

This applies the work around named in the errata:

  Disable Start-of-Frame Detection by writing '0' to the Start-of-Frame
  Detection Enable (SFDEN) bit in the USART Control B (USARTn.CTRLB) register
  when the device is in Active mode. Re-enable it by writing the bit to '1'
  before transitioning to Standby sleep mode. This work around depends on a
  protocol preventing a new incoming frame when re-enabling Start-of-Frame
  Detection. Re-enabling Start-of-Frame Detection, while a new frame is already
  incoming, will result in corrupted received data.

Only the clear is new - Sleep() already sets SFDEN immediately before
sleep_cpu(), so this does not move or add a re-enable point, and cannot make
that last condition any worse than it is today.  Whether a frame can be inbound
at that instant is a question about the protocol rather than this change, and I
have not established it either way: interpacketgap paces enqueue_task, not the
gap between frames on the wire.

The errata lists Rev. E as affected, and notes that revision is "the initial
release of the silicon" - no later revision is listed in the current document.
