### PR TITLE
INA229: read every shunt to its full rating, and fix the alert thresholds

### DIFF
--- a/ESPController/include/CurrentMonitorINA229.h
+++ b/ESPController/include/CurrentMonitorINA229.h
@@ -256,8 +256,8 @@ public:
     }
     float calc_overvoltagelimit()  const{ return (float)ConvertFrom2sComp(registers.R_BOVL) * 0.003125F; }
     float calc_undervoltagelimit()  const{ return (float)ConvertFrom2sComp(registers.R_BUVL) * 0.003125F; }
-    float calc_overcurrentlimit()  const{ return ((float)ConvertFrom2sComp(registers.R_SOVL) / 1000.0F * 1.25F) / full_scale_adc * registers.shunt_max_current; }
-    float calc_undercurrentlimit()  const{ return ((float)ConvertFrom2sComp(registers.R_SUVL) / 1000.0F * 1.25F) / full_scale_adc * registers.shunt_max_current; }
+    float calc_overcurrentlimit()  const{ return shunt_limit_amps(registers.R_SOVL); }
+    float calc_undercurrentlimit()  const{ return shunt_limit_amps(registers.R_SUVL); }
 
     bool calc_tempcompenabled() const { return (registers.R_CONFIG & bit(5)) != 0; }
 
@@ -284,6 +284,41 @@ private:
     float temperature = 0;
 
     const float full_scale_adc = 40.96F;
+
+    // SOVL and SUVL hold a shunt voltage, in units of 1.25uV while ADCRANGE is 1
+    // (INA229 datasheet SLYS023A, tables 7-17 and 7-18).  A current of I amps develops
+    // I * shunt_millivolt / shunt_max_current millivolts across the shunt, so a threshold
+    // of I amps is
+    //
+    //   I * shunt_millivolt * 1000 / (LSB_uV * shunt_max_current)
+    //
+    // A threshold beyond what the ADC can measure cannot be honoured, so clamp rather than
+    // let the value wrap round into a small - or negative - threshold.
+    static constexpr float SHUNT_LIMIT_MICROVOLT_LSB = 1.25F;
+    static constexpr int16_t SHUNT_LIMIT_REGISTER_MAX = 32767;
+
+    int16_t shunt_limit_register(int32_t centiamps) const
+    {
+        float reg = ((float)centiamps / 100.0F) * (float)registers.shunt_millivolt * 1000.0F /
+                    (SHUNT_LIMIT_MICROVOLT_LSB * (float)registers.shunt_max_current);
+
+        if (reg >= (float)SHUNT_LIMIT_REGISTER_MAX)
+        {
+            return SHUNT_LIMIT_REGISTER_MAX;
+        }
+        if (reg <= (float)-SHUNT_LIMIT_REGISTER_MAX)
+        {
+            return -SHUNT_LIMIT_REGISTER_MAX;
+        }
+        return (int16_t)reg;
+    }
+
+    float shunt_limit_amps(uint16_t reg) const
+    {
+        return (float)ConvertFrom2sComp(reg) * SHUNT_LIMIT_MICROVOLT_LSB *
+               (float)registers.shunt_max_current / ((float)registers.shunt_millivolt * 1000.0F);
+    }
+
     // const float CoulombsToAmpHours = 1.0F / 3600.0F;
     const float CoulombsToMilliAmpHours = 1.0F / 3.6F;
 

--- a/ESPController/include/CurrentMonitorINA229.h
+++ b/ESPController/include/CurrentMonitorINA229.h
@@ -161,7 +161,7 @@ public:
         // B1111 111 111 010 100 = 0xFFD4
         registers.R_ADC_CONFIG = 0xFFD4;
 
-        registers.R_CONFIG = _BV(4); // ADCRANGE = 40.96mV scale
+        registers.R_CONFIG = 0; // ADCRANGE = 0 = 163.84mV scale
 
         // Defaults for battery capacity/voltages
         registers.batterycapacity_amphour = 280;
@@ -216,6 +216,21 @@ public:
                    int32_t overpowerlimit,
                    uint16_t shunttempcoefficient,
                    bool TemperatureCompEnabled);
+
+    // Firmware before this change ran the ADC on its +-40.96mV range with a derated
+    // CURRENT_LSB, and that pair always calculates the same SHUNT_CAL, whatever shunt is
+    // fitted:
+    //
+    //   4 * 13107.2e6 * (40.96 / 1000 / 2^19) = 4096
+    //
+    // A calibration saved by one of those builds is therefore 4096 carrying the
+    // installation's trim - a percent or two, taking up shunt tolerance.  On the 163.84mV
+    // range the same trim belongs on shunt_millivolt/163.84 of it, so scaling the saved
+    // value across keeps the calibration instead of it having to be measured again.
+    static uint16_t CarryOverCalibration(uint16_t saved, uint16_t shuntmillivolt)
+    {
+        return (uint16_t)lround((float)saved * (float)shuntmillivolt / full_scale_adc);
+    }
 
     void DefaultSOC();
     void TakeReadings();
@@ -283,9 +298,25 @@ private:
     float power = 0;
     float temperature = 0;
 
-    const float full_scale_adc = 40.96F;
+    // CONFIG bit 4 (ADCRANGE) selects the shunt voltage full scale.  This driver uses the
+    // wide one, because the web UI offers shunts up to 150mV and the narrow range stops at
+    // 40.96mV - on the narrow range a 150A/50mV shunt reads no further than 122.88A, and a
+    // 500A/150mV shunt no further than 136.53A.
+    //
+    //   ADCRANGE=0  +-163.84mV   VSHUNT  312.5nV/LSB   SOVL/SUVL    5uV/LSB   SHUNT_CAL x1
+    //   ADCRANGE=1   +-40.96mV   VSHUNT 78.125nV/LSB   SOVL/SUVL 1.25uV/LSB   SHUNT_CAL x4
+    //
+    // (INA229 datasheet SLYS023A: table 8-1 full scale, table 7-9 VSHUNT, tables 7-17 and
+    //  7-18 SOVL/SUVL, equation 2 SHUNT_CAL)
+    //
+    // Nothing is given up for it.  Offset voltage, offset drift and gain error are each
+    // specified once, with no ADCRANGE qualifier, and the noise floor is lower in absolute
+    // terms: at the 4120us / 128 sample averaging configured above the datasheet gives 19.7
+    // noise-free bits over +-163.84mV against 17.1 over +-40.96mV, so 385nV against 582nV
+    // (table 8-2).
+    static constexpr float full_scale_adc = 163.84F;
 
-    // SOVL and SUVL hold a shunt voltage, in units of 1.25uV while ADCRANGE is 1
+    // SOVL and SUVL hold a shunt voltage, in units of 5uV while ADCRANGE is 0
     // (INA229 datasheet SLYS023A, tables 7-17 and 7-18).  A current of I amps develops
     // I * shunt_millivolt / shunt_max_current millivolts across the shunt, so a threshold
     // of I amps is
@@ -294,7 +325,7 @@ private:
     //
     // A threshold beyond what the ADC can measure cannot be honoured, so clamp rather than
     // let the value wrap round into a small - or negative - threshold.
-    static constexpr float SHUNT_LIMIT_MICROVOLT_LSB = 1.25F;
+    static constexpr float SHUNT_LIMIT_MICROVOLT_LSB = 5.0F;
     static constexpr int16_t SHUNT_LIMIT_REGISTER_MAX = 32767;
 
     int16_t shunt_limit_register(int32_t centiamps) const
@@ -318,6 +349,7 @@ private:
         return (float)ConvertFrom2sComp(reg) * SHUNT_LIMIT_MICROVOLT_LSB *
                (float)registers.shunt_max_current / ((float)registers.shunt_millivolt * 1000.0F);
     }
+
 
     // const float CoulombsToAmpHours = 1.0F / 3600.0F;
     const float CoulombsToMilliAmpHours = 1.0F / 3.6F;

--- a/ESPController/include/defines.h
+++ b/ESPController/include/defines.h
@@ -257,6 +257,11 @@ struct diybms_eeprom_settings
   uint8_t canbus_equipment_addr;  // battery index on the same canbus for PYLONFORCE, 0 - 15, default 0
   char homeassist_apikey[24+1];
 
+  /// @brief Commit date of the firmware that last wrote these settings, as a UNIX
+  /// timestamp.  Zero on an installation saved before the stamp existed.  Lets a change to
+  /// what a setting means be applied once, rather than every boot or not at all.
+  uint32_t settingswrittenby;
+
   /// @brief State of health variables - total lifetime mAh output (discharge)
   // Might need to watch overflow on the uint32 (max value 4,294,967,295mAh) = approx 15339 cycles of 280Ah battery
   uint32_t soh_total_milliamphour_out;

--- a/ESPController/src/CurrentMonitorINA229.cpp
+++ b/ESPController/src/CurrentMonitorINA229.cpp
@@ -464,9 +464,9 @@ bool CurrentMonitorINA229::Configure(uint16_t shuntmv,
     registers.R_SHUNT_TEMPCO = shunttempcoefficient & 0x3FFF;
 
     // Shunt Over Limit (current limit) = overcurrent protection
-    registers.R_SOVL = ConvertTo2sComp((((float)overcurrentlimit / 100.0F) * 1000.0F / 1.25F) * full_scale_adc / registers.shunt_max_current);
+    registers.R_SOVL = ConvertTo2sComp(shunt_limit_register(overcurrentlimit));
     // Shunt UNDER Limit (under current limit) = undercurrent protection
-    registers.R_SUVL = ConvertTo2sComp((((float)undercurrentlimit / 100.0F) * 1000.0F / 1.25F) * full_scale_adc / registers.shunt_max_current);
+    registers.R_SUVL = ConvertTo2sComp(shunt_limit_register(undercurrentlimit));
     // Bus Overvoltage (overvoltage protection).
     registers.R_BOVL = ConvertTo2sComp(((float)overvoltagelimit / 100.0F) / 0.003125F);
     // Bus under voltage protection

--- a/ESPController/src/CurrentMonitorINA229.cpp
+++ b/ESPController/src/CurrentMonitorINA229.cpp
@@ -36,32 +36,32 @@ void CurrentMonitorINA229::CalculateLSB()
     // in above - click COG icon top left.
     // https://e2e.ti.com/support/amplifiers-group/amplifiers/f/amplifiers-forum/1034569/ina228-accumulated-energy-and-charge-is-wrong
 
-    // 150A/50mV shunt =   full_scale_current= 150.00A / 50.00 * 40.96 = 122.88 AMPS
+    // 150A/50mV shunt =   50.00mV is inside the 163.84mV scale, so no derating
     //                     RSHUNT = (50 / 1000) / 150 = 0.00033333333
     //                     CURRENT_LSB = 150/ 524288 = 0.000286102294921875
-    //                     R_SHUNT_CAL = 52428800000*0.000286102294921875*0.00033333333 = 4999.999 = 5000
+    //                     R_SHUNT_CAL = 13107200000*0.000286102294921875*0.00033333333 = 1249.999 = 1250
 
-    // 300A/75mV shunt =   full_scale_current= 300.00A / 75.00 * 40.96 = 163.84 AMPS
-    //                     RSHUNT = (75 / 1000) / 163.84 = 0.000457763671875
-    //                     CURRENT_LSB = 163.84/ 524288 = 2.648162841796875e-4
-    //                     R_SHUNT_CAL = 52428800000*0.00057220458984375*0.00025 = 7499.9922688 = 7500
+    // 300A/75mV shunt =   75.00mV is inside the 163.84mV scale, so no derating
+    //                     RSHUNT = (75 / 1000) / 300 = 0.00025
+    //                     CURRENT_LSB = 300/ 524288 = 0.00057220458984375
+    //                     R_SHUNT_CAL = 13107200000*0.00057220458984375*0.00025 = 1875
 
     // Calculate CURRENT_LSB and R_SHUNT_CAL values
     // registers.full_scale_current = ((float)registers.shunt_max_current / (float)registers.shunt_millivolt) * full_scale_adc;
     registers.RSHUNT = ((float)registers.shunt_millivolt / 1000.0F) / (float)registers.shunt_max_current;
     registers.CURRENT_LSB = registers.shunt_max_current / (float)0x80000;
-    registers.R_SHUNT_CAL = 4L * (13107200000L * registers.CURRENT_LSB * registers.RSHUNT);
+    registers.R_SHUNT_CAL = 13107200000L * registers.CURRENT_LSB * registers.RSHUNT;
 
     ESP_LOGI(TAG, "RSHUNT=%.8f, CURRENT_LSB=%.8f, R_SHUNT_CAL=%u", registers.RSHUNT, registers.CURRENT_LSB, registers.R_SHUNT_CAL);
 
-    // Will the full scale current be over the 40.96mV range the ADC can handle?
+    // Will the full scale current be over the range the ADC can handle?
     if (((float)registers.shunt_max_current * registers.RSHUNT * 1000.0) > full_scale_adc)
     {
         float true_max_current = ((float)registers.shunt_max_current / (float)registers.shunt_millivolt) * full_scale_adc;
         ESP_LOGW(TAG, "WARNING: True Max Current Measurable %.2f Amps", true_max_current);
 
         registers.CURRENT_LSB = true_max_current / (float)0x80000;
-        registers.R_SHUNT_CAL = 4L * (13107200000L * registers.CURRENT_LSB * registers.RSHUNT);
+        registers.R_SHUNT_CAL = 13107200000L * registers.CURRENT_LSB * registers.RSHUNT;
         ESP_LOGI(TAG, "RECALC: RSHUNT=%.8f, CURRENT_LSB=%.8f, R_SHUNT_CAL=%u", registers.RSHUNT, registers.CURRENT_LSB, registers.R_SHUNT_CAL);
     }
 
@@ -287,11 +287,11 @@ int32_t CurrentMonitorINA229::readInt20(INA_REGISTER r)
 // Shunt voltage in MILLIVOLTS mV
 float CurrentMonitorINA229::ShuntVoltage()
 {
-    // 78.125 nV/LSB when ADCRANGE = 1
+    // 312.5 nV/LSB when ADCRANGE = 0
     // Differential voltage measured across the shunt output. Two's complement value.
     // 20 bit value max = 1048575
     int32_t vshunt = readInt20(INA_REGISTER::VSHUNT);
-    return (float)(((int64_t)vshunt) * 78125UL) / 1000000000.0;
+    return (float)(((int64_t)vshunt) * 312500UL) / 1000000000.0;
 }
 
 void CurrentMonitorINA229::TakeReadings()
@@ -479,7 +479,7 @@ bool CurrentMonitorINA229::Configure(uint16_t shuntmv,
 
     // ESP_LOGI(TAG, "undercurrentlimit=%f, R_SUVL=%u", ((float)undercurrentlimit / 100.0F), registers.R_SUVL);
 
-    registers.R_CONFIG = _BV(4); // ADCRANGE = 40.96mV scale
+    registers.R_CONFIG = 0; // ADCRANGE = 0 = 163.84mV scale
 
     if (TemperatureCompEnabled)
     {

--- a/ESPController/src/main.cpp
+++ b/ESPController/src/main.cpp
@@ -3875,6 +3875,29 @@ ESP32 Chip model = %u, Rev %u, Cores=%u, Features=%u)",
     {
       ESP_LOGI(TAG, "Onboard/internal current monitoring chip available");
 
+      // The ADC range below changes what SHUNT_CAL means, so a calibration saved by an
+      // earlier build belongs to a different scale.  Carry it over once, rather than
+      // applying it as it stands or asking for the shunt to be measured again.
+      //
+      // The constant only has to fall between the last build without the change and this
+      // one, because a build that has the change stamps the settings with its own date.
+      static constexpr uint32_t SHUNT_CAL_SCALE_CHANGED = 1786492800UL; // 2026-08-12
+
+      if (mysettings.settingswrittenby < SHUNT_CAL_SCALE_CHANGED)
+      {
+        if (mysettings.currentMonitoring_shuntcal != 0)
+        {
+          uint16_t saved = mysettings.currentMonitoring_shuntcal;
+          mysettings.currentMonitoring_shuntcal =
+              CurrentMonitorINA229::CarryOverCalibration(saved, mysettings.currentMonitoring_shuntmv);
+          ESP_LOGI(TAG, "Current shunt calibration %u carried over as %u", saved,
+                   mysettings.currentMonitoring_shuntcal);
+        }
+
+        mysettings.settingswrittenby = COMPILE_DATE_TIME_UTC_EPOCH;
+        SaveConfiguration(&mysettings);
+      }
+
       currentmon_internal.Configure(
           mysettings.currentMonitoring_shuntmv,
           mysettings.currentMonitoring_shuntmaxcur,

--- a/ESPController/src/settings.cpp
+++ b/ESPController/src/settings.cpp
@@ -91,6 +91,7 @@ static const char floatvoltagetimer_JSONKEY[] = "floatvoltagetimer";
 static const char stateofchargeresumevalue_JSONKEY[] = "stateofchargeresumevalue";
 static const char homeassist_apikey_JSONKEY[] = "homeassistapikey";
 
+static const char settingswrittenby_JSONKEY[] = "settingsWrittenBy";
 static const char soh_total_milliamphour_out_JSONKEY[] = "soh_mah_out";
 static const char soh_total_milliamphour_in_JSONKEY[] = "soh_mah_in";
 
@@ -192,6 +193,7 @@ static const char floatvoltagetimer_NVSKEY[] = "floatVtimer";
 static const char stateofchargeresumevalue_NVSKEY[] = "socresume";
 static const char homeassist_apikey_NVSKEY[] = "haapikey";
 
+static const char settingswrittenby_NVSKEY[] = "setwrittenby";
 static const char soh_total_milliamphour_out_NVSKEY[] = "soh_mah_out";
 static const char soh_total_milliamphour_in_NVSKEY[] = "soh_mah_in";
 static const char soh_lifetime_battery_cycles_NVSKEY[] = "soh_batcycle";
@@ -523,6 +525,7 @@ void SaveConfiguration(const diybms_eeprom_settings *settings)
 
         MACRO_NVSWRITESTRING(homeassist_apikey)
 
+        MACRO_NVSWRITE(settingswrittenby)
         MACRO_NVSWRITE(soh_total_milliamphour_out)
         MACRO_NVSWRITE(soh_total_milliamphour_in)
         MACRO_NVSWRITE(soh_lifetime_battery_cycles)
@@ -659,6 +662,7 @@ void LoadConfiguration(diybms_eeprom_settings *settings)
 
         MACRO_NVSREADSTRING(homeassist_apikey)
 
+        MACRO_NVSREAD(settingswrittenby)
         MACRO_NVSREAD(soh_total_milliamphour_out)
         MACRO_NVSREAD(soh_total_milliamphour_in)
         MACRO_NVSREAD(soh_lifetime_battery_cycles)
@@ -847,6 +851,9 @@ void DefaultConfiguration(diybms_eeprom_settings *_myset)
     _myset->stateofchargeresumevalue = 96;
 
     // State of health
+    // Zero, not this build.  LoadConfiguration lays the defaults down and then reads NVS
+    // key by key, so an installation saved before the stamp existed keeps the zero.
+    _myset->settingswrittenby = 0;
     _myset->soh_total_milliamphour_out = 0;
     _myset->soh_total_milliamphour_in = 0;
     _myset->soh_lifetime_battery_cycles = 6000;
@@ -1216,6 +1223,7 @@ void GenerateSettingsJSONDocument(JsonDocument &doc, diybms_eeprom_settings *set
 
     // wifi["password"] = DIYBMSSoftAP::Config().wifi_passphrase;
 
+    root[settingswrittenby_JSONKEY] = settings->settingswrittenby;
     root[soh_total_milliamphour_out_JSONKEY] = settings->soh_total_milliamphour_out;
     root[soh_total_milliamphour_in_JSONKEY] = settings->soh_total_milliamphour_in;
     root[soh_lifetime_battery_cycles_JSONKEY] = settings->soh_lifetime_battery_cycles;
@@ -1314,6 +1322,8 @@ void JSONToSettings(JsonDocument &doc, diybms_eeprom_settings *settings)
     settings->floatvoltagetimer = root[floatvoltagetimer_JSONKEY];
     settings->stateofchargeresumevalue = root[stateofchargeresumevalue_JSONKEY];
 
+    // Absent in a backup taken before the stamp existed, which reads back as zero
+    settings->settingswrittenby = root[settingswrittenby_JSONKEY];
     settings->soh_total_milliamphour_out = root[soh_total_milliamphour_out_JSONKEY];
     settings->soh_total_milliamphour_in = root[soh_total_milliamphour_in_JSONKEY];
     settings->soh_lifetime_battery_cycles = root[soh_lifetime_battery_cycles_JSONKEY];

--- a/ESPController/web_src/default.htm
+++ b/ESPController/web_src/default.htm
@@ -1285,8 +1285,8 @@
       <h2>Basic Settings</h2>
       <p id="b3">Ensure the current shunt parameters match the data sheet for your particular shunt resistor.</p>
       <p id="b4">
-        The DIYBMS current monitor uses a 40.96mV maximum scale, so shunt voltages over this will be scaled down
-        proportionally.
+        The DIYBMS current monitor uses a 163.84mV maximum scale, so every shunt listed here reads its full rated
+        current.
       </p>
       <p id="b11">
         Battery capacity and charge voltage/tail current are used to calculate the battery 'state of charge' (SOC).


### PR DESCRIPTION
The web UI offers 50, 60, 75, 100 and 150mV shunts, but the driver sets ADCRANGE=1, the INA229's ±40.96mV input range. Everything above that is out of reach, and `CalculateLSB()` derates to suit:

| shunt | reads no further than |
|---|---|
| 150A / 50mV | 122.88A |
| 50A / 75mV | 27.31A |
| 300A / 75mV | 163.84A |
| 100A / 100mV | 40.96A |
| 500A / 150mV | 136.53A |

27.31A is the ceiling reported in #214. Note the stock 150A/50mV shunt is on that list too — it has never read past 122.88A.

### Scale the current alert thresholds by the shunt

`SOVL`/`SUVL` hold a shunt voltage, but `Configure()` puts 40.96 where `shunt_millivolt` belongs, so the alert fires at `shunt_millivolt/40.96` of the setting — 82% of it on a 50mV shunt, 27% on a 150mV one. `calc_overcurrentlimit()` inverts the same expression, so the web UI hands back exactly what was typed and the error is invisible from outside. It is not cosmetic: `RelayTriggerCurrentOverLimit` routes SHNTOL to the ALERT pin.

The value does not always fit, either. `ConvertTo2sComp()` takes an `int16_t`, and the shipped defaults — 150.00A on the stock 150A/50mV shunt — come to exactly `32768.0f`. On xtensa that conversion compiles to `trunc.s` followed by `sext 15`, giving -32768, and the datasheet says a negative threshold trips on a 0V shunt reading. **Out of the box, with nothing configured, the over-current alert is asserted permanently.**

### Use ADCRANGE=0

Every shunt the UI offers fits inside 163.84mV, so the derating never applies. Four constants follow the bit and are moved together: the full scale, the `VSHUNT` LSB, the `SOVL`/`SUVL` LSB, and the ×4 on `SHUNT_CAL`.

Nothing is given up for it. Offset voltage, offset drift and gain error are each specified once in the datasheet, with no ADCRANGE qualifier, and the noise floor is lower in absolute terms — at the 4120µs / 128 sample averaging this driver configures, table 8-2 gives 19.7 noise-free bits over ±163.84mV against 17.1 over ±40.96mV, so 385nV against 582nV.

| shunt | reads to | SHUNT_CAL | alert set to the rating trips at |
|---|---|---|---|
| 150A / 50mV | 150.00A | 4096 → 1250 | 150.00A |
| 50A / 75mV | 50.00A | 4096 → 1875 | 50.00A |
| 300A / 75mV | 300.00A | 4096 → 1875 | 300.00A |
| 100A / 100mV | 100.00A | 4096 → 2500 | 100.00A |
| 500A / 150mV | 500.00A | 4096 → 3750 | 500.00A |

Simulating the datasheet's measurement chain end to end — amps, `VSHUNT` register, `CURRENT` register, reported amps — round trips to within 0.001% on every shunt above, and no clamping is reached anywhere.

### Saved calibrations are carried over, not measured again

`SHUNT_CAL` changes because `CURRENT_LSB` is no longer derated, so a saved Calibration belongs to a different scale — on a 50mV shunt it is 3.3× the value this configuration needs. The old range with a derated `CURRENT_LSB` always calculates the same value though, whatever shunt is fitted:

```
4 * 13107.2e6 * (40.96 / 1000 / 2^19) = 4096
```

So a saved calibration is 4096 carrying the installation's trim, and the same trim belongs on `shunt_millivolt/163.84` of it.

```
shunt          saved   carried over   calculated   trim
150A / 50mV     3994           1219         1250   -2.5% kept
100A / 60mV     3994           1463         1499   -2.4%
 50A / 75mV     3994           1828         1875   -2.5%
100A /100mV     3994           2438         2500   -2.5%
500A /150mV     3994           3657         3750   -2.5%
```

Which values need converting is not guessed at. Settings gain `settingswrittenby`, the commit date of the firmware that last wrote them. `LoadConfiguration()` lays the defaults down and then reads NVS key by key, so on an installation updated from an earlier build the key is simply absent and keeps its default of zero. Startup converts once and stamps the settings with this build's own date. A backup taken before the stamp existed restores as zero as well, and is converted the same way.

A date rather than a counter, so the same field carries any later change to what a setting means. The comparison is against a constant that only has to fall between the last build without the change and the one that makes it, because a build that has the change stamps its own date.

Carrying a -2.5% calibration across, the reported current moves by at most 0.024% - register quantisation, nothing else.

Updating over the air keeps the settings partition, so this is the path that matters. A full `esptool write_flash` of the merged image erases NVS and the controller comes up unconfigured, calibration included.

Fixes #214
