### PR TITLE
Work power out from bus voltage and current on both current monitors

### DIFF
--- a/ESPController/include/CurrentMonitorINA229.h
+++ b/ESPController/include/CurrentMonitorINA229.h
@@ -374,13 +374,6 @@ private:
         return v;
     }
 
-    // Calculated power output.  Output value in watts. Unsigned representation. Positive value.
-    float Power()
-    {
-        // POWER Power [W] = 3.2 x CURRENT_LSB x POWER
-        return (float)spi_readUint24(INA_REGISTER::POWER) * (float)3.2 * registers.CURRENT_LSB;
-    }
-
     // The INA228 device has an internal temperature sensor which can measure die temperature from –40 °C to +125°C.
     float DieTemperature()
     {

--- a/ESPController/src/CurrentMonitorINA229.cpp
+++ b/ESPController/src/CurrentMonitorINA229.cpp
@@ -298,14 +298,14 @@ void CurrentMonitorINA229::TakeReadings()
 {
     voltage = BusVoltage();
     current = Current();
-    power = Power();
 
     // https://github.com/stuartpittaway/diyBMSv4ESP32/issues/240
-    // INA229 is reported to have poor calculation of power at low levels
-    // this workaround overrides the power value below 200W
-    auto pow_val = voltage * abs(current);
-    ESP_LOGD(TAG, "V=%.4f, I=%.4f, P=%.2f, Calc_P=%.2f", voltage, current, power, pow_val);
-    if (pow_val < 200) { power = pow_val; }
+    // The chip's own POWER register is specified against full scale rather than against the
+    // reading - PTME +-0.5% - so its error is a fixed number of watts and swamps a small
+    // reading.  Bus voltage and shunt voltage are specified against the reading, at +-0.05%
+    // gain, so their product is the better figure everywhere, not just below 200W.
+    power = voltage * abs(current);
+    ESP_LOGD(TAG, "V=%.4f, I=%.4f, P=%.2f", voltage, current, power);
 
     temperature = DieTemperature();
     SOC = CalculateSOC();

--- a/ESPController/src/main.cpp
+++ b/ESPController/src/main.cpp
@@ -2492,6 +2492,13 @@ void ProcessDIYBMSCurrentMonitorRegisterReply(uint8_t length)
 
   // ESP_LOG_BUFFER_HEXDUMP(TAG, &currentMonitor.modbus, sizeof(currentmonitor_raw_modbus), esp_log_level_t::ESP_LOG_DEBUG);
 
+  // https://github.com/stuartpittaway/diyBMSv4ESP32/issues/240
+  // The shunt board sends a power figure taken from its INA228's POWER register, which is
+  // specified against full scale rather than against the reading, so its error is a fixed
+  // number of watts.  Voltage and current arrive in the same reply and are specified
+  // against the reading, so use those instead - the same thing the onboard monitor does.
+  currentMonitor.modbus.power = currentMonitor.modbus.voltage * abs(currentMonitor.modbus.current);
+
   currentMonitor.timestamp = esp_timer_get_time();
 
   // High byte


### PR DESCRIPTION
Issue #293 reports 62.61V and 0.04A shown as **86.25W**, on a build from several months after #240 was fixed. #240 is the same fault, and **its fix never reached this path**: the override lives inside `CurrentMonitorINA229`, and a shunt on the other end of RS485 never passes through it. The shunt board works the power out itself and sends the answer, already wrong.

`ProcessDIYBMSCurrentMonitorRegisterReply()` receives voltage, current and power out of the same reply, so one line there fixes every installation that updates the controller:

```
62.61V × 0.04A    86.25W  ->  2.50W
```

## Why the 200W threshold goes as well

Since 220c08bc, `TakeReadings()` has thrown the chip's figure away below 200W and used voltage × current instead. That was the cautious form of what was proposed in the #240 thread — *"ignoring the power reading completely from the chip and simply do voltage \* current"* — and the datasheet supports the complete form.

Power total measurement error is given as `PTME ±0.5%`, **"at full scale"** — not ±0.5% of the reading, but ±0.5% of the largest value the register can hold. Full scale is `CURRENT_LSB × 2^19`, which `CalculateLSB()` sets to `shunt_max_current`, multiplied by the 85V bus range:

```
shunt_max_current × 85V × 0.5%      150A stock shunt -> 63.8W
```

A fixed number of watts, however small the load. Bus voltage and shunt voltage are specified the other way round, **against the reading**: ±0.05% gain, with a ±1µV offset referred through the shunt. Their product is better at every load, not only under 200W:

| 150A / 50mV shunt | `POWER` register | bus voltage × current |
|---|---|---|
| 0.04A → 2.0W | ±63.8W | **±0.155W** |
| 10.00A → 512.0W | ±63.8W | **±0.410W** |
| 150.00A → 7.7kW | ±63.8W | **±3.994W** |

Sixteen times tighter even at full load, so there is no load at which reading `POWER` is worth doing. The threshold goes, and `Power()` with it.

## Notes

**The shunt board is fixed at source in parallel** by stuartpittaway/diyBMS-CurrentShunt#24, so a reflashed board sends the right number to begin with. This PR does not depend on that, and reaches the installations that will not be putting a UPDI programmer on an ATtiny inside a battery enclosure.

**Neither part touches the over power alarm, and neither needs to.** `POL` is raised inside the INA chip by comparing its own `POWER` register against `PWR_LIMIT`, so no firmware change can reach it — but the same fixed error is under 1% of the 5kW default limit, against 3450% of a 2.5W reading. It is only the reported value that was unusable.

**The PZEM-017 path is left alone.** It has its own registers, is not an INA228, and its power figure has not been reported as wrong.
