### PR TITLE
Offer only the calibration multipliers a module will keep

### DIFF
--- a/ESPController/web_src/default.htm
+++ b/ESPController/web_src/default.htm
@@ -405,7 +405,7 @@
             </div>
             <div>
               <label for="Calib">Calibration multiplier</label>
-              <input id="Calib" name="Calib" type="number" min="0.5" max="5" step="0.0001" value="1" required="" />
+              <input id="Calib" name="Calib" type="number" min="0.8" max="10" step="0.0001" value="1" required="" />
               <label for="ActualVoltage">Calculator - Actual measured voltage</label>
               <input id="ActualVoltage" name="ActualVoltage" type="number" min="1" max="5" step="0.001" value="4.2" />
               <button type="button" id="CalculateCalibration">Calculate</button>


### PR DESCRIPTION
The **Calibration multiplier** box accepts `0.5` to `5`. The module keeps `0.8` to `10.0`. Both ends disagree, and the low end is the dangerous one.

```
web_src/default.htm            min="0.5" max="5"
ATTINYCellModule/src/main.cpp  ValidateConfiguration()
                               if (Calibration < 0.8 || > 10.0)
```

## What happens to a value the module will not keep

**It is not rejected.** Nothing on the way to the module looks at it — `webserver_json_post.cpp` reads the float out of the form and hands it to `sendSaveSetting()` — and the module's `WriteSettings` handler only checks that it is not the `0xFFFF` "unset" marker:

```cpp
// packet_processor.cpp
if (myFloat.number < 0xFFFF)
{
  _config->Calibration = myFloat.number;
}
...
Settings::WriteConfigToEEPROM(...);
```

So it is **stored in EEPROM and used**, because every cell voltage is that multiplier times the raw reading:

```cpp
v = ((raw_adc_voltage / SAMPLEAVERAGING) * MV_PER_ADC) * _config->Calibration;
```

`ValidateConfiguration()` is the only thing that enforces `0.8 - 10.0`, and **it runs in `setup()` and nowhere else**, so it cannot see a value that arrives while the module is running. The correction happens at the next power up.

### The result, on a real board

Enter `0.5` on an ATTINY841, whose default is `2.2007`, and the module reports `0.5 / 2.2007` = **22.7% of the real voltage** from the next reading onwards.

| | |
|---|---|
| a 4.2V cell reads | **0.95V** |
| the controller sees | no over voltage → **charging is not stopped** |
| it also sees | what looks like a flat cell |
| how long | **until the module is power cycled** |
| then the multiplier becomes | `2.2007` — a number the user did not enter and was not shown |

**The form is the only thing that can send this value**, so refusing it in the form removes the path entirely.

## Why max goes up as well as min

The two ends should be the module's two ends, and the module's ceiling is `10.0`. A board needing more than 5 cannot be calibrated through the form today even though the module would keep the value. That the ATTINY841 default is already `2.2007` shows multipliers well above 1 are ordinary here, so 5 is not the comfortable margin it looks like.

## Origin

[diyBMSv4Code#135](https://github.com/stuartpittaway/diyBMSv4Code/issues/135). The complaint there was that values below `1.000` could not be entered at all; the ESP32 rewrite fixed that, and the mismatched limits are what was left.

## Not in this change

That the module **accepts, stores and uses a multiplier it would reject at power up** is a separate fault with a wider blast radius than one input box, and it is not fixed here. `ValidateConfiguration()` would need to run when settings arrive, not only in `setup()`. Happy to send that as a follow-up if you want it.
