### PR TITLE
Check settings when they arrive, not only at power up

### DIFF
--- a/ATTINYCellModule/include/defines.h
+++ b/ATTINYCellModule/include/defines.h
@@ -67,4 +67,9 @@ struct CellModuleConfig {
   //uint16_t External_BCoefficient;
 } __attribute__((packed));
 
+// Clamp any setting that is out of range back to something the module can run
+// on.  Defined in main.cpp, called both at power up and whenever settings
+// arrive over the wire.
+void ValidateConfiguration();
+
 #endif

--- a/ATTINYCellModule/src/packet_processor.cpp
+++ b/ATTINYCellModule/src/packet_processor.cpp
@@ -358,14 +358,6 @@ bool PacketProcessor::processPacket(PacketStruct *buffer)
     if (buffer->moduledata[6] != 0xFF)
     {
       _config->BypassTemperatureSetPoint = buffer->moduledata[6];
-
-#if defined(DIYBMSMODULEVERSION) && (DIYBMSMODULEVERSION == 420 && !defined(SWAPR19R20))
-      // Keep temperature low for modules with R19 and R20 not swapped
-      if (_config->BypassTemperatureSetPoint > 45)
-      {
-        _config->BypassTemperatureSetPoint = 45;
-      }
-#endif
     }
 
     if (buffer->moduledata[7] != 0xFFFF)
@@ -381,6 +373,10 @@ bool PacketProcessor::processPacket(PacketStruct *buffer)
     //{
     //       _config->External_BCoefficient = buffer.moduledata[9];
     // }
+
+    // The same check the module makes at power up.  Without it a setting the
+    // module would have rejected is stored and used until it is next reset.
+    ValidateConfiguration();
 
     // Save settings
     Settings::WriteConfigToEEPROM((uint8_t *)_config, sizeof(CellModuleConfig), EEPROM_CONFIG_ADDRESS);


### PR DESCRIPTION
A module will not run on a calibration multiplier outside `0.8 - 10.0`. It says so itself, and it is right to: the multiplier scales every cell voltage it reports. **But it only says so once, at power up.**

```
main.cpp   void ValidateConfiguration()     defined line 174
main.cpp   ValidateConfiguration();         called line 268, in setup()
```

Nothing calls it again. A multiplier that arrives over the wire while the module is running is not measured against that range at all — the `WriteSettings` handler only checks that it is not the "unset" marker:

```cpp
if (myFloat.number < 0xFFFF)
{
  _config->Calibration = myFloat.number;
}
...
Settings::WriteConfigToEEPROM(...);
```

so it is written to EEPROM, and used from the next reading onwards:

```cpp
v = ((raw_adc_voltage / SAMPLEAVERAGING) * MV_PER_ADC) * _config->Calibration;
```

## What that costs

Send `0.5` to an ATTINY841, whose default is `2.2007`, and every voltage it reports becomes `0.5 / 2.2007` = **22.7% of the real one**.

| | |
|---|---|
| a full 4.2V cell reads | **0.95V** |
| the controller sees | no over voltage → **it does not stop charging** |
| and at the same time | what looks like a flat cell |
| for how long | **until the module is power cycled** |
| then the multiplier becomes | `2.2007` — a number nobody entered and nobody was shown |

## The change

Call the same function before the settings are stored:

```cpp
ValidateConfiguration();

// Save settings
Settings::WriteConfigToEEPROM(...);
```

**Before the write**, so EEPROM never holds a value the module has already decided it will not run on, and before any reading can be taken with it. Placing it here rather than in the `loop()` body that watches `SettingsHaveChanged` matters: `loop()` reaches that block on its *next* pass, by which time the value is in EEPROM and the module may have answered a voltage request with it.

**It takes no argument.** There is exactly one `PacketProcessor` —

```cpp
PacketProcessor PP(&myConfig);
```

— so `_config` and `myConfig` are the same object, and letting the function keep using the global was **measured 26 bytes smaller** than passing the pointer in. On a part with 238 bytes left that is worth having.

## One check is now duplicated, so it goes

The handler carried its own copy of the V420 temperature clamp:

```diff
 if (buffer->moduledata[6] != 0xFF)
 {
   _config->BypassTemperatureSetPoint = buffer->moduledata[6];
-  if (_config->BypassTemperatureSetPoint > 45) ...
 }
```

`ValidateConfiguration()` applies the same clamp to the same field, and applies it **whether or not a new setpoint was sent**, so removing the copy leaves strictly more checking than before, not less. V420 is the tightest build, and this pays back 10 of the 52 bytes.

## Size

```
V400              7,832 -> 7,882    +50     310 bytes free
V410              7,828 -> 7,878    +50     314
V420              7,912 -> 7,954    +42     238   <- tightest
V420_SWAPR19R20   7,898 -> 7,948    +50     244
V421              7,890 -> 7,940    +50     252
V421_LTO          7,826 -> 7,876    +50     316
V440              7,842 -> 7,892    +50     300
V440_COMMS_5K     7,842 -> 7,892    +50     300
V440_COMMS_9K6    7,842 -> 7,892    +50     300
```

RAM is unchanged at 254 bytes on every one. The V450 builds need #325 before they compile at all; measured on top of it they go `8,372 -> 8,420`, with 7,964 bytes of the 16K part still free.

## Notes

**#333 stops the web form offering a multiplier outside the range**, which is the only way one can be sent today. This is the other half: the module no longer depends on being asked nicely.

**STM32All-In-One is not covered.** It has no equivalent check to call — its `Cell::setCalibration()` stores whatever it is given, and nothing validates the multiplier there even at power up. That is a different gap and wants its own change.
